### PR TITLE
Bump version number; update file headers

### DIFF
--- a/lib/mo_pack/__init__.py
+++ b/lib/mo_pack/__init__.py
@@ -1,22 +1,10 @@
-# (C) British Crown Copyright 2015, Met Office
+# Copyright mo_pack contributors
 #
-# This file is part of mo_pack.
-#
-# mo_pack is free software: you can redistribute it and/or modify it under
-# the terms of the GNU Lesser General Public License as published by the
-# Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# mo_pack is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with mo_pack. If not, see <http://www.gnu.org/licenses/>.
+# This file is part of mo_pack and is released under the BSD license.
+# See LICENSE in the root of the repository for full licensing details.
 from __future__ import absolute_import, division, print_function
 
 from ._packing import (compress_rle, compress_wgdos,
                        decompress_rle, decompress_wgdos)
 
-__version__ = '0.2.0'
+__version__ = '0.2.0.post0'

--- a/lib/mo_pack/_packing.pyx
+++ b/lib/mo_pack/_packing.pyx
@@ -1,20 +1,7 @@
-# (C) British Crown Copyright 2015, Met Office
+# Copyright mo_pack contributors
 #
-# This file is part of mo_pack.
-#
-# mo_pack is free software: you can redistribute it and/or modify it under
-# the terms of the GNU Lesser General Public License as published by the
-# Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# mo_pack is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with mo_pack. If not, see <http://www.gnu.org/licenses/>.
-
+# This file is part of mo_pack and is released under the BSD license.
+# See LICENSE in the root of the repository for full licensing details.
 from __future__ import absolute_import, division, print_function
 
 import numpy as np

--- a/lib/mo_pack/tests/__init__.py
+++ b/lib/mo_pack/tests/__init__.py
@@ -1,19 +1,7 @@
-# (C) British Crown Copyright 2015, Met Office
+# Copyright mo_pack contributors
 #
-# This file is part of mo_pack.
-#
-# mo_pack is free software: you can redistribute it and/or modify it under
-# the terms of the GNU Lesser General Public License as published by the
-# Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# mo_pack is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with mo_pack. If not, see <http://www.gnu.org/licenses/>.
+# This file is part of mo_pack and is released under the BSD license.
+# See LICENSE in the root of the repository for full licensing details.
 """Tests for mo_pack."""
 
 from __future__ import absolute_import, division, print_function

--- a/lib/mo_pack/tests/test_compress_rle.py
+++ b/lib/mo_pack/tests/test_compress_rle.py
@@ -1,19 +1,7 @@
-# (C) British Crown Copyright 2015, Met Office
+# Copyright mo_pack contributors
 #
-# This file is part of mo_pack.
-#
-# mo_pack is free software: you can redistribute it and/or modify it under
-# the terms of the GNU Lesser General Public License as published by the
-# Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# mo_pack is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with mo_pack. If not, see <http://www.gnu.org/licenses/>.
+# This file is part of mo_pack and is released under the BSD license.
+# See LICENSE in the root of the repository for full licensing details.
 """Tests for the `mo_pack.compress_rle` function."""
 
 from __future__ import absolute_import, division, print_function

--- a/lib/mo_pack/tests/test_decompress_rle.py
+++ b/lib/mo_pack/tests/test_decompress_rle.py
@@ -1,19 +1,7 @@
-# (C) British Crown Copyright 2015, Met Office
+# Copyright mo_pack contributors
 #
-# This file is part of mo_pack.
-#
-# mo_pack is free software: you can redistribute it and/or modify it under
-# the terms of the GNU Lesser General Public License as published by the
-# Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# mo_pack is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with mo_pack. If not, see <http://www.gnu.org/licenses/>.
+# This file is part of mo_pack and is released under the BSD license.
+# See LICENSE in the root of the repository for full licensing details.
 """Tests for the `mo_pack.decompress_rle` function."""
 
 from __future__ import absolute_import, division, print_function

--- a/lib/mo_pack/tests/test_rle.py
+++ b/lib/mo_pack/tests/test_rle.py
@@ -1,19 +1,7 @@
-# (C) British Crown Copyright 2015, Met Office
+# Copyright mo_pack contributors
 #
-# This file is part of mo_pack.
-#
-# mo_pack is free software: you can redistribute it and/or modify it under
-# the terms of the GNU Lesser General Public License as published by the
-# Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# mo_pack is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with mo_pack. If not, see <http://www.gnu.org/licenses/>.
+# This file is part of mo_pack and is released under the BSD license.
+# See LICENSE in the root of the repository for full licensing details.
 """
 Integration tests for the `mo_pack.compress_rle` and
 `mo_pack.decompress_rle` functions.

--- a/lib/mo_pack/tests/test_wgdos.py
+++ b/lib/mo_pack/tests/test_wgdos.py
@@ -1,19 +1,7 @@
-# (C) British Crown Copyright 2015, Met Office
+# Copyright mo_pack contributors
 #
-# This file is part of mo_pack.
-#
-# mo_pack is free software: you can redistribute it and/or modify it under
-# the terms of the GNU Lesser General Public License as published by the
-# Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# mo_pack is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with mo_pack. If not, see <http://www.gnu.org/licenses/>.
+# This file is part of mo_pack and is released under the BSD license.
+# See LICENSE in the root of the repository for full licensing details.
 """
 Tests for the `mo_pack.compress_wgdos` and `mo_pack.decompress_wgdos`
 functions.

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ extensions = [setuptools.Extension('mo_pack._packing',
 setup(
     name='mo_pack',
     description='Python wrapper to libmo_unpack',
-    version='0.2.0',
+    version='0.2.0.post0',
     ext_modules=cythonize(extensions),
     packages=['mo_pack', 'mo_pack.tests'],
     package_dir={'': 'lib'},


### PR DESCRIPTION
To update the conda-forge build so that it includes the new license we will need to make a post release.

- In this PR I have update the version number `0.2.0` -> `0.2.0.post0`
- I also noticed that the headers were the old style and they mentioned `GNU Lesser General Public License`. Unfortunately my grepping didn't catch this as I only thought to look for `(L)GPL`. I have updated the headers as was done for tepih