### PR TITLE
NumPy 2 Compatibility

### DIFF
--- a/src/mo_pack/_packing.pyx
+++ b/src/mo_pack/_packing.pyx
@@ -5,6 +5,8 @@
 import numpy as np
 cimport numpy as np
 
+# Must be called to use the C-API with Numpy
+np.import_array()
 
 #: The WGDOS packing algorithm generally produces smaller data payloads
 #: than the unpacked equivalent. However this is not a given, especially


### PR DESCRIPTION
This passes all tests locally, as well as allowing all Iris tests to pass. Without this change neither of those statements is true!