### PR TITLE
Mambaforge update

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -40,7 +40,7 @@ jobs:
     - name: "conda install"
       uses: conda-incubator/setup-miniconda@v3
       with:
-        miniforge-variant: Mambaforge
+        miniforge-variant: Miniforge3
         miniforge-version: latest
         python-version: ${{ matrix.python-version }}
         activate-environment: mo-pack-dev


### PR DESCRIPTION
A recent release of Miniforge has broke this CI the fix requires renaming Mambaforge to Miniforge

Propagating this fix over from python-stratify
https://github.com/SciTools/python-stratify/pull/302