### PR TITLE
Changes for Ruff compliance

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,19 +153,6 @@ line-length = 88
 preview = false
 
 [tool.ruff.lint]
-ignore = [
-    # NOTE: Non-permanent exclusions should be added to the ".ruff.toml" file.
-
-    # flake8-commas (COM)
-    # https://docs.astral.sh/ruff/rules/#flake8-commas-com
-    "COM812",  # Trailing comma missing.
-    "COM819",  # Trailing comma prohibited.
-
-    # flake8-implicit-str-concat (ISC)
-    # https://docs.astral.sh/ruff/rules/single-line-implicit-string-concatenation/
-    # NOTE: This rule may cause conflicts when used with "ruff format".
-    "ISC001",  # Implicitly concatenate string literals on one line.
-    ]
     preview = false
     select = [
         "ALL",

--- a/src/mo_pack/tests/test_wgdos.py
+++ b/src/mo_pack/tests/test_wgdos.py
@@ -36,7 +36,8 @@ class TestPackWGDOS:
 
     def test_accuracy(self):
         data = np.array(
-            [[0.1234, 0.2345, 0.3456], [0.4567, 0.5678, 0.6789]], dtype=np.float32
+            [[0.1234, 0.2345, 0.3456], [0.4567, 0.5678, 0.6789]],
+            dtype=np.float32,
         )
         compressed = mo_pack.compress_wgdos(data, accuracy=-4)
         decompressed_data = mo_pack.decompress_wgdos(compressed, 2, 3)


### PR DESCRIPTION
Just a trailing comma needed to fix `COM812` (which forced a line-break).
`COM819` and `ISC001` ignores appear to be unnecessary.