### PR TITLE
Ruff compliance for `tests`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -171,7 +171,7 @@ force-sort-within-sections = true
    # "D100",  # Missing docstring in public module
    # "D101",  # Missing docstring in public class
    # "D102",  # Missing docstring in public method
-    "D205",  # 1 blank line required between summary line and description
+   # "D205",  # 1 blank line required between summary line and description
     "D401",  # 1 First line of docstring should be in imperative mood
 
     "ANN",   # https://docs.astral.sh/ruff/rules/#flake8-annotations-ann

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -168,8 +168,8 @@ force-sort-within-sections = true
 
 "src/mo_pack/tests/*.py" = [
     # https://docs.astral.sh/ruff/rules/undocumented-public-module/
-    "D100",  # Missing docstring in public module
-    "D101",  # Missing docstring in public class
+   # "D100",  # Missing docstring in public module
+   # "D101",  # Missing docstring in public class
     "D102",  # Missing docstring in public method
     "D205",  # 1 blank line required between summary line and description
     "D401",  # 1 First line of docstring should be in imperative mood

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -170,7 +170,7 @@ force-sort-within-sections = true
     # https://docs.astral.sh/ruff/rules/undocumented-public-module/
    # "D100",  # Missing docstring in public module
    # "D101",  # Missing docstring in public class
-    "D102",  # Missing docstring in public method
+   # "D102",  # Missing docstring in public method
     "D205",  # 1 blank line required between summary line and description
     "D401",  # 1 First line of docstring should be in imperative mood
 

--- a/src/mo_pack/tests/test_compress_rle.py
+++ b/src/mo_pack/tests/test_compress_rle.py
@@ -14,6 +14,7 @@ class Test:
     """Tests for run-length encoding compression."""
 
     def test_no_mdi(self):
+        """Test RLE compression of data with no MDI values."""
         data = np.arange(42, dtype=np.float32).reshape(7, 6)
         compressed_data = compress_rle(data)
         expected = np.arange(42, dtype="f4")
@@ -21,6 +22,7 @@ class Test:
         assert compressed_data == expected.data
 
     def test_mdi(self):
+        """Test RLE compression of data with MDI values."""
         data = np.arange(12, dtype=np.float32).reshape(3, 4) + 5
         data[1, 1:] = 999
         compressed_data = compress_rle(data, missing_data_indicator=999)
@@ -29,8 +31,7 @@ class Test:
         assert compressed_data == expected.data
 
     def test_mdi_larger(self):
-        # Check that everything still works if the compressed data are
-        # *larger* than the original data.
+        """Test RLE compression fails if compressed data larger than original data."""
         data = np.arange(12, dtype=np.float32).reshape(3, 4) + 5
         data[data % 2 == 0] = 666
         with pytest.raises(ValueError, match="WGDOS exit code was non-zero"):

--- a/src/mo_pack/tests/test_compress_rle.py
+++ b/src/mo_pack/tests/test_compress_rle.py
@@ -11,6 +11,8 @@ from mo_pack import compress_rle
 
 
 class Test:
+    """Tests for run-length encoding compression."""
+
     def test_no_mdi(self):
         data = np.arange(42, dtype=np.float32).reshape(7, 6)
         compressed_data = compress_rle(data)

--- a/src/mo_pack/tests/test_decompress_rle.py
+++ b/src/mo_pack/tests/test_decompress_rle.py
@@ -12,6 +12,8 @@ from mo_pack import decompress_rle
 
 
 class Test:
+    """Tests for run-length encoding decompression."""
+
     def test_no_mdi(self):
         # The input to decompress_rle must be big-endian 32-bit floats.
         src_buffer = np.arange(12, dtype=">f4").data

--- a/src/mo_pack/tests/test_decompress_rle.py
+++ b/src/mo_pack/tests/test_decompress_rle.py
@@ -15,6 +15,7 @@ class Test:
     """Tests for run-length encoding decompression."""
 
     def test_no_mdi(self):
+        """Test RLE decompression of data with no MDI values."""
         # The input to decompress_rle must be big-endian 32-bit floats.
         src_buffer = np.arange(12, dtype=">f4").data
         result = decompress_rle(src_buffer, 3, 4)
@@ -22,6 +23,7 @@ class Test:
         assert result.dtype == np.dtype("=f4")
 
     def test_mdi(self):
+        """Test RLE decompression of data with MDI values."""
         # The input to decompress_rle must be big-endian 32-bit floats.
         src_floats = np.arange(11, dtype=">f4")
         src_floats[5] = 666
@@ -31,11 +33,13 @@ class Test:
         assert_array_equal(result, [[0, 1, 2, 3], [4, 666, 666, 666], [7, 8, 9, 10]])
 
     def test_not_enough_source_data(self):
+        """Test RLE decompression fails when source data that is too small."""
         src_buffer = np.arange(4, dtype=">f4").data
         with pytest.raises(ValueError, match="RLE exit code was non-zero"):
             decompress_rle(src_buffer, 5, 6)
 
     def test_too_much_source_data(self):
+        """Test RLE decompression fails when source data that is too large."""
         src_buffer = np.arange(10, dtype=">f4").data
         with pytest.raises(ValueError, match="RLE exit code was non-zero"):
             decompress_rle(src_buffer, 2, 3)

--- a/src/mo_pack/tests/test_rle.py
+++ b/src/mo_pack/tests/test_rle.py
@@ -24,10 +24,12 @@ class Test:
         assert_array_equal(result, original)
 
     def test_no_mdi(self):
+        """Test compression of data with no MDI values."""
         data = np.arange(42, dtype=np.float32).reshape(7, 6)
         self._test(data, 7, 6)
 
     def test_mdi(self):
+        """Test compression of data with MDI values."""
         data = np.arange(12, dtype=np.float32).reshape(3, 4) + 5
         data[1, 1:] = 999
         self._test(data, 3, 4)

--- a/src/mo_pack/tests/test_rle.py
+++ b/src/mo_pack/tests/test_rle.py
@@ -16,6 +16,8 @@ MDI = 999
 
 
 class Test:
+    """Integration tests for run-length encoding compression."""
+
     def _test(self, original, rows, cols):
         compressed_data = compress_rle(original, missing_data_indicator=MDI)
         result = decompress_rle(compressed_data, rows, cols, missing_data_indicator=MDI)

--- a/src/mo_pack/tests/test_rle.py
+++ b/src/mo_pack/tests/test_rle.py
@@ -2,10 +2,7 @@
 #
 # This file is part of mo_pack and is released under the BSD license.
 # See LICENSE in the root of the repository for full licensing details.
-"""Integration tests for the `mo_pack.compress_rle` and
-`mo_pack.decompress_rle` functions.
-
-"""
+"""Integration tests for `mo_pack.compress_rle` and `mo_pack.decompress_rle`."""
 
 import numpy as np
 from numpy.testing import assert_array_equal
@@ -24,12 +21,12 @@ class Test:
         assert_array_equal(result, original)
 
     def test_no_mdi(self):
-        """Test compression of data with no MDI values."""
+        """Test RLE compression of data with no MDI values."""
         data = np.arange(42, dtype=np.float32).reshape(7, 6)
         self._test(data, 7, 6)
 
     def test_mdi(self):
-        """Test compression of data with MDI values."""
+        """Test RLE compression of data with MDI values."""
         data = np.arange(12, dtype=np.float32).reshape(3, 4) + 5
         data[1, 1:] = 999
         self._test(data, 3, 4)

--- a/src/mo_pack/tests/test_wgdos.py
+++ b/src/mo_pack/tests/test_wgdos.py
@@ -20,16 +20,19 @@ class TestPackWGDOS:
     """Tests for WGDOS compression."""
 
     def assert_equal_when_decompressed(self, compressed_data, expected_array, mdi=0):
+        """Assert that decompressed data equal compressed data."""
         x, y = expected_array.shape
         decompressed_data = mo_pack.decompress_wgdos(compressed_data, x, y, mdi)
         np.testing.assert_array_equal(decompressed_data, expected_array)
 
     def test_pack_wgdos(self):
+        """Test WGDOS compression of data with no MDI values."""
         data = np.arange(42, dtype=np.float32).reshape(7, 6)
         compressed_data = mo_pack.compress_wgdos(data)
         self.assert_equal_when_decompressed(compressed_data, data)
 
     def test_mdi(self):
+        """Test WGDOS compression of data with MDI values."""
         data = np.arange(12, dtype=np.float32).reshape(3, 4)
         compressed_data = mo_pack.compress_wgdos(data, missing_data_indicator=4.0)
         expected_data = data
@@ -37,6 +40,7 @@ class TestPackWGDOS:
         self.assert_equal_when_decompressed(compressed_data, expected_data, mdi=4.0)
 
     def test_accuracy(self):
+        """Test WGDOS compression with reduced accuracy."""
         data = np.array(
             [[0.1234, 0.2345, 0.3456], [0.4567, 0.5678, 0.6789]],
             dtype=np.float32,
@@ -57,18 +61,21 @@ class TestdecompressWGDOS:
     """Tests for WGDOS decompression."""
 
     def test_incorrect_size(self):
+        """Test WGDOS decompression correctly fails for incorrect source array size."""
         data = np.arange(77, dtype=np.float32).reshape(7, 11)
         compressed_data = mo_pack.compress_wgdos(data)
         with pytest.raises(ValueError, match="WGDOS exit code was non-zero"):
             _ = mo_pack.decompress_wgdos(compressed_data, 5, 6)
 
     def test_different_shape(self):
+        """Test decompressed data equal to source data when both are reshaped."""
         data = np.arange(24, dtype=np.float32).reshape(8, 3)
         compressed_data = mo_pack.compress_wgdos(data)
         decompressed_data = mo_pack.decompress_wgdos(compressed_data, 4, 6)
         np.testing.assert_array_equal(decompressed_data, data.reshape(4, 6))
 
     def test_real_data(self):
+        """Test WGDOS decompression of a real PP dataset."""
         test_dir = Path(__file__).parent.resolve()
         fname = test_dir / "test_data" / "nae.20100104-06_0001_0001.pp"
         with fname.open("rb") as fh:

--- a/src/mo_pack/tests/test_wgdos.py
+++ b/src/mo_pack/tests/test_wgdos.py
@@ -17,6 +17,8 @@ import mo_pack
 
 
 class TestPackWGDOS:
+    """Tests for WGDOS compression."""
+
     def assert_equal_when_decompressed(self, compressed_data, expected_array, mdi=0):
         x, y = expected_array.shape
         decompressed_data = mo_pack.decompress_wgdos(compressed_data, x, y, mdi)
@@ -52,6 +54,8 @@ class TestPackWGDOS:
 
 
 class TestdecompressWGDOS:
+    """Tests for WGDOS decompression."""
+
     def test_incorrect_size(self):
         data = np.arange(77, dtype=np.float32).reshape(7, 11)
         compressed_data = mo_pack.compress_wgdos(data)

--- a/src/mo_pack/tests/test_wgdos.py
+++ b/src/mo_pack/tests/test_wgdos.py
@@ -2,10 +2,7 @@
 #
 # This file is part of mo_pack and is released under the BSD license.
 # See LICENSE in the root of the repository for full licensing details.
-"""Tests for the `mo_pack.compress_wgdos` and `mo_pack.decompress_wgdos`
-functions.
-
-"""
+"""Tests for `mo_pack.compress_wgdos` and `mo_pack.decompress_wgdos`."""
 
 from pathlib import Path
 


### PR DESCRIPTION
Fixes the following in `tests/*.py`:
 - `D100`  # Missing docstring in public module
 - `D101`  # Missing docstring in public class
 - `D102`,  # Missing docstring in public method
 - `D205`,  # 1 blank line required between summary line and description

Ref: #96