### PR TITLE
Ruff: type hints for `tests/*.py`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -82,7 +82,6 @@ repos:
     rev: 'v1.15.0'
     hooks:
     -   id: mypy
-        #exclude: 'src\/mo_pack\/tests'
 
 -   repo: https://github.com/abravalheri/validate-pyproject
     # More exhaustive than Ruff RUF200.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -82,7 +82,7 @@ repos:
     rev: 'v1.15.0'
     hooks:
     -   id: mypy
-        exclude: 'src\/mo_pack\/tests'
+        #exclude: 'src\/mo_pack\/tests'
 
 -   repo: https://github.com/abravalheri/validate-pyproject
     # More exhaustive than Ruff RUF200.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,9 +138,6 @@ ignore_missing_imports = true
 warn_unused_configs = true
 warn_unreachable = true
 enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]
-#exclude = [
-#    "src\\/mo_pack\\/tests$",
-#]
 strict = true
 
 [tool.ruff]
@@ -170,8 +167,6 @@ force-sort-within-sections = true
    # "D102",  # Missing docstring in public method
    # "D205",  # 1 blank line required between summary line and description
     "D401",  # 1 First line of docstring should be in imperative mood
-
-    #"ANN",   # https://docs.astral.sh/ruff/rules/#flake8-annotations-ann
     "S101",  # Use of assert detected
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,9 +141,9 @@ ignore_missing_imports = true
 warn_unused_configs = true
 warn_unreachable = true
 enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]
-exclude = [
-    "src\\/mo_pack\\/tests$",
-]
+#exclude = [
+#    "src\\/mo_pack\\/tests$",
+#]
 strict = true
 
 [tool.ruff]
@@ -174,7 +174,7 @@ force-sort-within-sections = true
     "D205",  # 1 blank line required between summary line and description
     "D401",  # 1 First line of docstring should be in imperative mood
 
-    "ANN",   # https://docs.astral.sh/ruff/rules/#flake8-annotations-ann
+    #"ANN",   # https://docs.astral.sh/ruff/rules/#flake8-annotations-ann
     "S101",  # Use of assert detected
 ]
 

--- a/src/mo_pack/tests/test_compress_rle.py
+++ b/src/mo_pack/tests/test_compress_rle.py
@@ -11,14 +11,14 @@ from mo_pack import compress_rle
 
 
 class Test:
-    def test_no_mdi(self):
+    def test_no_mdi(self) -> None:
         data = np.arange(42, dtype=np.float32).reshape(7, 6)
         compressed_data = compress_rle(data)
         expected = np.arange(42, dtype="f4")
         expected.byteswap(inplace=True)
         assert compressed_data == expected.data
 
-    def test_mdi(self):
+    def test_mdi(self) -> None:
         data = np.arange(12, dtype=np.float32).reshape(3, 4) + 5
         data[1, 1:] = 999
         compressed_data = compress_rle(data, missing_data_indicator=999)
@@ -26,7 +26,7 @@ class Test:
         expected.byteswap(inplace=True)
         assert compressed_data == expected.data
 
-    def test_mdi_larger(self):
+    def test_mdi_larger(self) -> None:
         # Check that everything still works if the compressed data are
         # *larger* than the original data.
         data = np.arange(12, dtype=np.float32).reshape(3, 4) + 5

--- a/src/mo_pack/tests/test_decompress_rle.py
+++ b/src/mo_pack/tests/test_decompress_rle.py
@@ -12,14 +12,14 @@ from mo_pack import decompress_rle
 
 
 class Test:
-    def test_no_mdi(self):
+    def test_no_mdi(self) -> None:
         # The input to decompress_rle must be big-endian 32-bit floats.
         src_buffer = np.arange(12, dtype=">f4").data
         result = decompress_rle(src_buffer, 3, 4)
         assert_array_equal(result, np.arange(12).reshape(3, 4))
         assert result.dtype == np.dtype("=f4")
 
-    def test_mdi(self):
+    def test_mdi(self) -> None:
         # The input to decompress_rle must be big-endian 32-bit floats.
         src_floats = np.arange(11, dtype=">f4")
         src_floats[5] = 666
@@ -28,12 +28,12 @@ class Test:
         result = decompress_rle(src_buffer, 3, 4, missing_data_indicator=666)
         assert_array_equal(result, [[0, 1, 2, 3], [4, 666, 666, 666], [7, 8, 9, 10]])
 
-    def test_not_enough_source_data(self):
+    def test_not_enough_source_data(self) -> None:
         src_buffer = np.arange(4, dtype=">f4").data
         with pytest.raises(ValueError, match="RLE exit code was non-zero"):
             decompress_rle(src_buffer, 5, 6)
 
-    def test_too_much_source_data(self):
+    def test_too_much_source_data(self) -> None:
         src_buffer = np.arange(10, dtype=">f4").data
         with pytest.raises(ValueError, match="RLE exit code was non-zero"):
             decompress_rle(src_buffer, 2, 3)

--- a/src/mo_pack/tests/test_rle.py
+++ b/src/mo_pack/tests/test_rle.py
@@ -9,6 +9,7 @@
 
 import numpy as np
 from numpy.testing import assert_array_equal
+from numpy.typing import NDArray
 
 from mo_pack import compress_rle, decompress_rle
 
@@ -16,16 +17,16 @@ MDI = 999
 
 
 class Test:
-    def _test(self, original, rows, cols):
+    def _test(self, original: NDArray, rows: int, cols: int) -> None:
         compressed_data = compress_rle(original, missing_data_indicator=MDI)
         result = decompress_rle(compressed_data, rows, cols, missing_data_indicator=MDI)
         assert_array_equal(result, original)
 
-    def test_no_mdi(self):
+    def test_no_mdi(self) -> None:
         data = np.arange(42, dtype=np.float32).reshape(7, 6)
         self._test(data, 7, 6)
 
-    def test_mdi(self):
+    def test_mdi(self) -> None:
         data = np.arange(12, dtype=np.float32).reshape(3, 4) + 5
         data[1, 1:] = 999
         self._test(data, 3, 4)

--- a/src/mo_pack/tests/test_wgdos.py
+++ b/src/mo_pack/tests/test_wgdos.py
@@ -11,30 +11,36 @@ from pathlib import Path
 
 import numpy as np
 from numpy.testing import assert_almost_equal, assert_array_equal
+from numpy.typing import NDArray
 import pytest
 
 import mo_pack
 
 
 class TestPackWGDOS:
-    def assert_equal_when_decompressed(self, compressed_data, expected_array, mdi=0):
+    def assert_equal_when_decompressed(
+        self,
+        compressed_data: memoryview,
+        expected_array: NDArray,
+        mdi: float = 0,
+    ) -> None:
         x, y = expected_array.shape
         decompressed_data = mo_pack.decompress_wgdos(compressed_data, x, y, mdi)
         np.testing.assert_array_equal(decompressed_data, expected_array)
 
-    def test_pack_wgdos(self):
+    def test_pack_wgdos(self) -> None:
         data = np.arange(42, dtype=np.float32).reshape(7, 6)
         compressed_data = mo_pack.compress_wgdos(data)
         self.assert_equal_when_decompressed(compressed_data, data)
 
-    def test_mdi(self):
+    def test_mdi(self) -> None:
         data = np.arange(12, dtype=np.float32).reshape(3, 4)
         compressed_data = mo_pack.compress_wgdos(data, missing_data_indicator=4.0)
         expected_data = data
         data[1, 0] = 4.0
         self.assert_equal_when_decompressed(compressed_data, expected_data, mdi=4.0)
 
-    def test_accuracy(self):
+    def test_accuracy(self) -> None:
         data = np.array(
             [[0.1234, 0.2345, 0.3456], [0.4567, 0.5678, 0.6789]],
             dtype=np.float32,
@@ -52,19 +58,19 @@ class TestPackWGDOS:
 
 
 class TestdecompressWGDOS:
-    def test_incorrect_size(self):
+    def test_incorrect_size(self) -> None:
         data = np.arange(77, dtype=np.float32).reshape(7, 11)
         compressed_data = mo_pack.compress_wgdos(data)
         with pytest.raises(ValueError, match="WGDOS exit code was non-zero"):
             _ = mo_pack.decompress_wgdos(compressed_data, 5, 6)
 
-    def test_different_shape(self):
+    def test_different_shape(self) -> None:
         data = np.arange(24, dtype=np.float32).reshape(8, 3)
         compressed_data = mo_pack.compress_wgdos(data)
         decompressed_data = mo_pack.decompress_wgdos(compressed_data, 4, 6)
         np.testing.assert_array_equal(decompressed_data, data.reshape(4, 6))
 
-    def test_real_data(self):
+    def test_real_data(self) -> None:
         test_dir = Path(__file__).parent.resolve()
         fname = test_dir / "test_data" / "nae.20100104-06_0001_0001.pp"
         with fname.open("rb") as fh:


### PR DESCRIPTION
Adds type hints to `tests/*.py`.
Also removes the `exclude` of test directory in mypy linter.