### PR TITLE
Address Ruff S101 compliance

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,8 +157,5 @@ preview = false
 [tool.ruff.lint.isort]
 force-sort-within-sections = true
 
-[tool.ruff.lint.per-file-ignores]
-# All test scripts.
-
 [tool.ruff.lint.pydocstyle]
 convention = "numpy"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -160,15 +160,5 @@ force-sort-within-sections = true
 [tool.ruff.lint.per-file-ignores]
 # All test scripts.
 
-"src/mo_pack/tests/*.py" = [
-    # https://docs.astral.sh/ruff/rules/undocumented-public-module/
-   # "D100",  # Missing docstring in public module
-   # "D101",  # Missing docstring in public class
-   # "D102",  # Missing docstring in public method
-   # "D205",  # 1 blank line required between summary line and description
-    "D401",  # 1 First line of docstring should be in imperative mood
-    "S101",  # Use of assert detected
-]
-
 [tool.ruff.lint.pydocstyle]
 convention = "numpy"

--- a/src/mo_pack/tests/test_compress_rle.py
+++ b/src/mo_pack/tests/test_compress_rle.py
@@ -5,6 +5,7 @@
 """Tests for the `mo_pack.compress_rle` function."""
 
 import numpy as np
+from numpy.testing import assert_array_equal
 import pytest
 
 from mo_pack import compress_rle
@@ -19,7 +20,7 @@ class Test:
         compressed_data = compress_rle(data)
         expected = np.arange(42, dtype="f4")
         expected.byteswap(inplace=True)
-        assert compressed_data == expected.data
+        assert_array_equal(compressed_data, expected.data)
 
     def test_mdi(self) -> None:
         """Test RLE compression of data with MDI values."""
@@ -28,7 +29,7 @@ class Test:
         compressed_data = compress_rle(data, missing_data_indicator=999)
         expected = np.array([5, 6, 7, 8, 9, 999, 3, 13, 14, 15, 16], dtype="f4")
         expected.byteswap(inplace=True)
-        assert compressed_data == expected.data
+        assert_array_equal(compressed_data, expected.data)
 
     def test_mdi_larger(self) -> None:
         """Test RLE compression fails if compressed data larger than original data."""

--- a/src/mo_pack/tests/test_decompress_rle.py
+++ b/src/mo_pack/tests/test_decompress_rle.py
@@ -20,7 +20,7 @@ class Test:
         src_buffer = np.arange(12, dtype=">f4").data
         result = decompress_rle(src_buffer, 3, 4)
         assert_array_equal(result, np.arange(12).reshape(3, 4))
-        assert result.dtype == np.dtype("=f4")
+        assert result.dtype == np.dtype("=f4")  # noqa: S101
 
     def test_mdi(self) -> None:
         """Test RLE decompression of data with MDI values."""


### PR DESCRIPTION
Addressed Ruff S101 compliance (use of asserts).
 - Changed two `asserts` to `numpy.assert_array_equal`
 - Added `noqa: S101` to an existing assert (unless there is a better way of handling?)

Also cleaned up `pyproject.toml`.