### PR TITLE
ci: generate token for ci-locks pull-request

### DIFF
--- a/.github/workflows/ci-locks.yml
+++ b/.github/workflows/ci-locks.yml
@@ -56,12 +56,19 @@ jobs:
           pixi workspace export conda-explicit-spec --environment ${{ env.NAME }} --frozen --ignore-pypi-errors requirements
           pixi workspace export conda-environment --environment ${{ env.NAME }} requirements/mo-pack.yml
 
+      - name: "generate token"
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
+        id: generate-token
+        with:
+          app_id: ${{ secrets.AUTH_APP_ID }}
+          private_key: ${{ secrets.AUTH_APP_PRIVATE_KEY }}
+
       - name: "create pull-request"
         id: cpr
         if: ${{ hashFiles('diff.md') }}
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.generate-token.outputs.token }}
           add-paths: |
             ${{ github.workspace }}/pixi.lock
             ${{ github.workspace }}/requirements/mo-pack*.txt

--- a/.github/workflows/ci-locks.yml
+++ b/.github/workflows/ci-locks.yml
@@ -24,10 +24,6 @@ defaults:
   run:
     shell: bash -l {0}
 
-permissions:
-  contents: write
-  pull-requests: write
-
 jobs:
   locks-update:
     name: "update lockfiles"

--- a/.github/workflows/ci-locks.yml
+++ b/.github/workflows/ci-locks.yml
@@ -57,11 +57,11 @@ jobs:
           pixi workspace export conda-environment --environment ${{ env.NAME }} requirements/mo-pack.yml
 
       - name: "generate token"
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
+        uses: actions/create-github-app-token@v2
         id: generate-token
         with:
-          app_id: ${{ secrets.AUTH_APP_ID }}
-          private_key: ${{ secrets.AUTH_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.AUTH_APP_ID }}
+          private-qkey: ${{ secrets.AUTH_APP_PRIVATE_KEY }}
 
       - name: "create pull-request"
         id: cpr

--- a/.github/workflows/ci-locks.yml
+++ b/.github/workflows/ci-locks.yml
@@ -61,7 +61,7 @@ jobs:
         id: generate-token
         with:
           app-id: ${{ secrets.AUTH_APP_ID }}
-          private-qkey: ${{ secrets.AUTH_APP_PRIVATE_KEY }}
+          private-key: ${{ secrets.AUTH_APP_PRIVATE_KEY }}
 
       - name: "create pull-request"
         id: cpr


### PR DESCRIPTION
Use the `scitools` GH app to generate a pull-request token.

Reference [comment](https://github.com/SciTools/mo_pack/pull/150#pullrequestreview-2806953738).